### PR TITLE
Add Docker build setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM php:8.3-cli-alpine
+
+# Install build dependencies and prepare the source
+RUN apk add --no-cache --virtual .build-deps \
+        autoconf gcc g++ make php8-dev linux-headers gmp-dev \
+    && docker-php-source extract
+
+# Copy extension sources
+COPY ./ext /usr/src/php/ext/sqids
+
+# Build and install the extension
+RUN cd /usr/src/php/ext/sqids \
+    && phpize \
+    && ./configure --enable-sqids \
+    && make -j$(nproc) \
+    && make install
+
+# Enable the extension
+COPY ./php.ini /usr/local/etc/php/conf.d/sqids.ini
+
+# Cleanup build dependencies
+RUN docker-php-source delete \
+    && apk del .build-deps
+
+CMD ["php", "-a"]

--- a/README.md
+++ b/README.md
@@ -72,3 +72,18 @@ pear package
 ```
 
 Upload the resulting `.tgz` file on [PECL](https://pecl.php.net/).
+
+## Building with Docker
+
+The repository contains a `Dockerfile` that compiles and installs the
+extension inside an Alpine based PHP image. Build the image with:
+
+```bash
+docker build -t php-with-sqids .
+```
+
+Run the container and verify that the extension loads correctly:
+
+```bash
+docker run --rm php-with-sqids php -m | grep sqids
+```

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,1 @@
+extension=sqids.so


### PR DESCRIPTION
## Summary
- add Dockerfile for building the sqids extension
- provide php.ini enabling the extension
- document Docker build instructions

## Testing
- `./vendor/bin/phpunit ide-stubs/tests`

------
https://chatgpt.com/codex/tasks/task_e_686dc2e317108330a94c531f33d64205